### PR TITLE
fix: remove duplicate 'Thinking' text in first assistant message

### DIFF
--- a/apps/desktop/src/components/agent/ChatMessage.tsx
+++ b/apps/desktop/src/components/agent/ChatMessage.tsx
@@ -75,8 +75,6 @@ export const ChatMessage = memo(function ChatMessage({
               <div className="prose prose-sm prose-invert max-w-none">
                 <ReactMarkdown>{message.content}</ReactMarkdown>
               </div>
-            ) : isAssistantStreaming ? (
-              <p className="text-sm text-muted-foreground">Thinking...</p>
             ) : null}
 
             {hasReasoning && (


### PR DESCRIPTION
## Summary
- Fixes #5 — duplicate "Thinking" indicator shown when the first assistant message arrives
- Removed the redundant `"Thinking..."` body placeholder text in `ChatMessage.tsx`; the spinner badge already communicates the thinking state

## Test plan
- [ ] Start a new agent session and send a message
- [ ] Verify only one "Thinking" indicator appears (spinner badge)
- [ ] Verify "Streaming response" appears once content starts flowing
- [ ] Verify the collapsible reasoning section still works when reasoning is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)