### PR TITLE
fix: add error handling to branch checkout on Changes page

### DIFF
--- a/apps/desktop/src/components/git/RemoteActions.tsx
+++ b/apps/desktop/src/components/git/RemoteActions.tsx
@@ -18,6 +18,7 @@ export function RemoteActions({ localPath }: RemoteActionsProps) {
   const pushMutation = useGitPush();
   const checkoutMutation = useCheckoutBranch();
   const [branchMenuOpen, setBranchMenuOpen] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const localBranches = branches.filter((b) => !b.isRemote);
@@ -66,7 +67,16 @@ export function RemoteActions({ localPath }: RemoteActionsProps) {
                 )}
                 onClick={() => {
                   if (!branch.isHead) {
-                    checkoutMutation.mutate({ path: localPath, name: branch.name });
+                    setActionError(null);
+                    checkoutMutation.mutate(
+                      { path: localPath, name: branch.name },
+                      {
+                        onError: (err) =>
+                          setActionError(
+                            err instanceof Error ? err.message : String(err),
+                          ),
+                      },
+                    );
                   }
                   setBranchMenuOpen(false);
                 }}
@@ -135,6 +145,12 @@ export function RemoteActions({ localPath }: RemoteActionsProps) {
         )}
         Push
       </Button>
+
+      {actionError && (
+        <div className="mx-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-1.5">
+          <p className="text-xs text-red-400">{actionError}</p>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Branch switching from the Changes page failed silently — `RemoteActions` called `checkoutMutation.mutate()` without an `onError` callback
- Added `actionError` state, `onError` handler, and error banner UI matching the existing pattern in `BranchList.tsx`
- Users now see a red error banner (e.g. "Commit or stash your changes first") instead of silent failure

Closes #11

## Test plan
- [ ] Navigate to Changes page, make uncommitted changes, try switching branches — verify error banner appears
- [ ] With clean working tree, switch branches — verify it succeeds with no error
- [ ] After seeing an error, attempt another checkout — verify error clears before new attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)