### PR TITLE
feat: add ability to delete remote branches

### DIFF
--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -119,6 +119,20 @@ pub async fn git_delete_branch(path: String, name: String, force: Option<bool>) 
 }
 
 #[tauri::command]
+pub async fn git_delete_remote_branch(
+    path: String,
+    remote: String,
+    branch: String,
+    token: String,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        crate::git::branch::delete_remote_branch(&path, &remote, &branch, &token)
+    })
+    .await
+    .map_err(|e| format!("Task failed: {e}"))?
+}
+
+#[tauri::command]
 pub async fn git_rename_branch(
     path: String,
     old_name: String,

--- a/apps/desktop/src-tauri/src/git/branch.rs
+++ b/apps/desktop/src-tauri/src/git/branch.rs
@@ -173,6 +173,27 @@ pub fn delete_branch(path: &str, name: &str, force: bool) -> Result<(), String> 
     Ok(())
 }
 
+pub fn delete_remote_branch(path: &str, remote: &str, branch: &str, token: &str) -> Result<(), String> {
+    let repo = Repository::open(path).map_err(|e| format!("Failed to open repo: {e}"))?;
+
+    let mut remote_obj = repo
+        .find_remote(remote)
+        .map_err(|e| format!("Failed to find remote '{remote}': {e}"))?;
+
+    let callbacks = crate::git::remote::make_callbacks(token);
+    let mut push_opts = git2::PushOptions::new();
+    push_opts.remote_callbacks(callbacks);
+
+    // Push empty source to delete the remote branch
+    let refspec = format!(":refs/heads/{branch}");
+
+    remote_obj
+        .push(&[&refspec], Some(&mut push_opts))
+        .map_err(|e| format!("Failed to delete remote branch '{remote}/{branch}': {e}"))?;
+
+    Ok(())
+}
+
 pub fn rename_branch(path: &str, old_name: &str, new_name: &str) -> Result<(), String> {
     let repo = Repository::open(path).map_err(|e| format!("Failed to open repo: {e}"))?;
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -87,6 +87,7 @@ pub fn run() {
             commands::git::git_create_branch,
             commands::git::git_checkout_branch,
             commands::git::git_delete_branch,
+            commands::git::git_delete_remote_branch,
             commands::git::git_rename_branch,
             commands::git::git_get_current_branch,
             commands::git::git_stage_files,

--- a/apps/desktop/src/components/git/BranchList.tsx
+++ b/apps/desktop/src/components/git/BranchList.tsx
@@ -15,6 +15,7 @@ import {
   useCreateBranch,
   useCheckoutBranch,
   useDeleteBranch,
+  useDeleteRemoteBranch,
 } from "@/queries/useGitMutations";
 import { cn } from "@/lib/utils";
 import type { BranchInfo } from "@forge/shared";
@@ -30,6 +31,7 @@ export function BranchList({ localPath }: BranchListProps) {
   const createBranch = useCreateBranch();
   const checkoutBranch = useCheckoutBranch();
   const deleteBranch = useDeleteBranch();
+  const deleteRemoteBranch = useDeleteRemoteBranch();
 
   const [showNewBranch, setShowNewBranch] = useState(false);
   const [newBranchName, setNewBranchName] = useState("");
@@ -82,6 +84,25 @@ export function BranchList({ localPath }: BranchListProps) {
             setActionError(message);
             setPendingForceDelete(null);
           }
+        },
+      },
+    );
+  };
+
+  const handleDeleteRemote = (fullName: string) => {
+    // Parse "origin/feature-x" → remote: "origin", branch: "feature-x"
+    const slashIndex = fullName.indexOf("/");
+    if (slashIndex === -1) return;
+    const remote = fullName.slice(0, slashIndex);
+    const branch = fullName.slice(slashIndex + 1);
+
+    if (!window.confirm(`Delete remote branch '${fullName}'? This will remove it from the remote repository.`)) return;
+    setActionError(null);
+    deleteRemoteBranch.mutate(
+      { path: localPath, remote, branch },
+      {
+        onError: (err) => {
+          setActionError(err instanceof Error ? err.message : String(err));
         },
       },
     );
@@ -201,6 +222,7 @@ export function BranchList({ localPath }: BranchListProps) {
             branch={branch}
             isCurrent={false}
             isRemote
+            onDelete={() => handleDeleteRemote(branch.name)}
           />
         ))}
         {remoteBranches.length === 0 && (
@@ -275,7 +297,7 @@ function BranchRow({
       <span className="shrink-0 font-mono text-xs text-muted-foreground">
         {branch.commitOid.slice(0, 7)}
       </span>
-      {!isRemote && !isCurrent && (
+      {!isCurrent && (
         <div className="hidden shrink-0 items-center gap-0.5 group-hover:flex">
           {onCheckout && (
             <Button

--- a/apps/desktop/src/ipc/git.ts
+++ b/apps/desktop/src/ipc/git.ts
@@ -12,6 +12,8 @@ export const gitIpc = {
     invoke<BranchInfo>("git_create_branch", { path, name, fromRef: fromRef ?? null }),
   checkoutBranch: (path: string, name: string) => invoke<void>("git_checkout_branch", { path, name }),
   deleteBranch: (path: string, name: string, force?: boolean) => invoke<void>("git_delete_branch", { path, name, force: force ?? null }),
+  deleteRemoteBranch: (path: string, remote: string, branch: string, token: string) =>
+    invoke<void>("git_delete_remote_branch", { path, remote, branch, token }),
   renameBranch: (path: string, oldName: string, newName: string) =>
     invoke<void>("git_rename_branch", { path, oldName, newName }),
   getCurrentBranch: (path: string) => invoke<string | null>("git_get_current_branch", { path }),

--- a/apps/desktop/src/queries/useGitMutations.ts
+++ b/apps/desktop/src/queries/useGitMutations.ts
@@ -140,6 +140,18 @@ export function useDeleteBranch() {
   });
 }
 
+export function useDeleteRemoteBranch() {
+  const queryClient = useQueryClient();
+  const token = useAuthStore((s) => s.token);
+  return useMutation({
+    mutationFn: async ({ path, remote, branch }: { path: string; remote: string; branch: string }) =>
+      gitIpc.deleteRemoteBranch(path, remote, branch, token!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["git-branches"] });
+    },
+  });
+}
+
 export function useRenameBranch() {
   const queryClient = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Summary
- Adds `delete_remote_branch()` Rust function using git2 push with empty refspec (`:refs/heads/<branch>`)
- Wires through Tauri command → IPC → React Query mutation with token auth
- Shows delete button (trash icon) on remote branch rows in the Branches page
- Confirmation dialog warns: "This will remove it from the remote repository"

Closes #15

## Test plan
- [ ] Open app, navigate to Branches page
- [ ] Expand "Remote Branches" section
- [ ] Hover a remote branch row → trash icon appears
- [ ] Click trash → confirmation dialog with remote deletion warning
- [ ] Confirm → branch deleted from remote, list refreshes
- [ ] Cancel confirmation → nothing happens
- [ ] Test with nested branch name (e.g., `origin/feature/nested`) → parses correctly
- [ ] Test with invalid auth → error displays in red error box

🤖 Generated with [Claude Code](https://claude.com/claude-code)