### PR TITLE
fix(codex): unify Codex backend event protocol (#17)

### DIFF
--- a/apps/desktop/src-tauri/src/agent/codex_backend.rs
+++ b/apps/desktop/src-tauri/src/agent/codex_backend.rs
@@ -28,9 +28,6 @@ pub struct CodexBackend {
     request_counter: Arc<AtomicU64>,
     /// Maps JSON-RPC server request IDs to their method + itemId for approval routing
     pending_approvals: Arc<Mutex<std::collections::HashMap<String, PendingApproval>>>,
-    turn_start_time: Arc<Mutex<Option<std::time::Instant>>>,
-    input_tokens: Arc<Mutex<u64>>,
-    output_tokens: Arc<Mutex<u64>>,
 }
 
 #[derive(Clone)]
@@ -345,9 +342,6 @@ impl CodexBackend {
             turn_id,
             request_counter,
             pending_approvals,
-            turn_start_time,
-            input_tokens,
-            output_tokens,
         })
     }
 
@@ -1096,6 +1090,60 @@ mod tests {
         assert!(matches!(&events[0], AgentEvent::ApprovalRequested {
             tool_name, detail, ..
         } if tool_name == "file_edit" && detail.contains("src/main.rs")));
+    }
+
+    #[test]
+    fn token_usage_updated_accumulates_and_returns_empty() {
+        let (thread_id, turn_id, pending_approvals, turn_start_time, input_tokens, output_tokens) = test_state();
+        let events = parse_codex_notification(
+            "thread/tokenUsage/updated",
+            &serde_json::json!({
+                "inputTokens": 1500,
+                "outputTokens": 300
+            }),
+            false,
+            None,
+            &thread_id,
+            &turn_id,
+            &pending_approvals,
+            &turn_start_time,
+            &input_tokens,
+            &output_tokens,
+        );
+        assert!(events.is_empty(), "tokenUsage should not emit visible events");
+        assert_eq!(*input_tokens.lock().unwrap(), 1500);
+        assert_eq!(*output_tokens.lock().unwrap(), 300);
+    }
+
+    #[test]
+    fn thread_started_emits_session_meta_with_conversation_id() {
+        let (thread_id, turn_id, pending_approvals, turn_start_time, input_tokens, output_tokens) = test_state();
+        // Reset thread_id to None so thread/started can set it
+        *thread_id.lock().unwrap() = None;
+        let events = parse_codex_notification(
+            "thread/started",
+            &serde_json::json!({
+                "thread": {
+                    "id": "thread-abc-123"
+                }
+            }),
+            false,
+            None,
+            &thread_id,
+            &turn_id,
+            &pending_approvals,
+            &turn_start_time,
+            &input_tokens,
+            &output_tokens,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], AgentEvent::SessionMeta {
+            provider, conversation_id, ..
+        } if provider.as_deref() == Some("codex")
+            && conversation_id.as_deref() == Some("thread-abc-123")
+        ));
+        // Verify thread_id was stored
+        assert_eq!(thread_id.lock().unwrap().as_deref(), Some("thread-abc-123"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Brings the Codex backend into event parity with the Claude backend so the frontend renders consistently regardless of which AI provider is active. All changes are scoped to `codex_backend.rs` — no frontend modifications needed since it's already backend-agnostic.

- **Permission mode unification** — Codex now emits `"supervised"/"assisted"/"fullAccess"` instead of internal strings (`"untrusted"/"on-request"/"never"`), fixing the status bar display
- **Approval flow fix** — Emits `ApprovalRequested` + `Status{AwaitingApproval}` (matching Claude), fixing broken permission prompts and enabling auto-approval in fullAccess mode
- **ThinkingStart emission** — Reasoning items emit `ThinkingStart` instead of `Raw`, enabling the collapsible reasoning UI
- **SessionMeta emission** — Provider metadata emitted at spawn and on thread start
- **Duration tracking** — `Result` events now report actual elapsed time instead of `0`
- **Token usage tracking** — Accumulates input/output tokens from `tokenUsage` notifications
- **Vec return type** — `parse_codex_notification` returns `Vec<AgentEvent>` matching Claude's `parse_host_events` pattern

### Permission mode mapping

| Unified (frontend) | Codex approvalPolicy | Codex sandboxPermissions |
|---|---|---|
| `supervised` | `"untrusted"` | `"read-only"` |
| `assisted` | `"on-request"` | `"workspace-write"` |
| `fullAccess` | `"never"` | `"danger-full-access"` |

### Known limitations

- Mid-session mode changes only update metadata — Codex's `approvalPolicy` is set at `thread/start` time with no JSON-RPC method to change it. Frontend auto-approval logic compensates.
- Cost tracking stays at `$0.00` — Codex doesn't provide cost data in its protocol.

## Test plan

- [x] `cargo check` — zero warnings
- [x] `cargo test --lib codex_backend` — 10 tests pass (4 existing updated + 6 new)
- [ ] Manual: start Codex session, verify permission prompts show tool name + input
- [ ] Manual: switch to fullAccess mode, verify auto-approval works
- [ ] Manual: verify reasoning section appears and is collapsible

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)