### PR TITLE
Add plan mode support to agent sessions

### DIFF
--- a/apps/claude-host/src/index.ts
+++ b/apps/claude-host/src/index.ts
@@ -23,6 +23,7 @@ type HostCommand =
       prompt: string;
       model?: string | null;
       permissionMode?: string | null;
+      underlyingPermissionMode?: string | null;
       effort?: string | null;
       agent?: string | null;
       claudePath?: string | null;
@@ -195,6 +196,7 @@ interface ClaudeSession {
   sessionId: string;
   cwd?: string | null;
   permissionMode?: string | null;
+  underlyingPermissionMode?: string | null;
   claudePath?: string | null;
   agent?: string | null;
   effort?: string | null;
@@ -361,6 +363,7 @@ async function createCapabilitiesQuery(claudePath?: string | null) {
 
 function toSdkPermissionMode(mode?: string | null): PermissionMode | undefined {
   switch (mode) {
+    case "plan": return "plan";
     case "supervised": return "default";
     case "assisted": return "default";
     case "fullAccess": return "bypassPermissions";
@@ -391,6 +394,7 @@ async function startSession(command: Extract<HostCommand, { type: "start_session
     sessionId: command.sessionId,
     cwd: command.cwd,
     permissionMode: command.permissionMode ?? undefined,
+    underlyingPermissionMode: command.underlyingPermissionMode ?? command.permissionMode ?? undefined,
     claudePath: command.claudePath ?? undefined,
     agent: command.agent ?? undefined,
     effort: command.effort ?? undefined,
@@ -403,13 +407,14 @@ async function startSession(command: Extract<HostCommand, { type: "start_session
   };
 
   const canUseTool: CanUseTool = (toolName, toolInput, callbackOptions) => {
+    const effectiveMode = session.underlyingPermissionMode ?? session.permissionMode;
     // Full Access: auto-approve all tools
-    if (session.permissionMode === "fullAccess") {
+    if (effectiveMode === "fullAccess") {
       return Promise.resolve({ behavior: "allow" as const });
     }
 
     // Assisted: auto-approve read-only tools, prompt for writes
-    if (session.permissionMode === "assisted" && READ_ONLY_TOOLS.has(toolName)) {
+    if (effectiveMode === "assisted" && READ_ONLY_TOOLS.has(toolName)) {
       return Promise.resolve({ behavior: "allow" as const });
     }
 

--- a/apps/desktop/src-tauri/src/agent/claude_backend.rs
+++ b/apps/desktop/src-tauri/src/agent/claude_backend.rs
@@ -34,6 +34,7 @@ impl ClaudeBackend {
         working_directory: Option<&str>,
         initial_prompt: &str,
         claude: Option<&ClaudeLaunchOptions>,
+        plan_mode: bool,
         app_handle: AppHandle,
     ) -> Result<Self, String> {
         let node_path = resolve_node_path()?;
@@ -168,6 +169,16 @@ impl ClaudeBackend {
             approval_lookup,
         };
 
+        let plan_mode_enabled = plan_mode;
+        let base_permission = claude
+            .and_then(|opts| opts.permission_mode.clone())
+            .or_else(|| Some(mode_to_permission_mode(mode).to_string()));
+        let effective_permission = if plan_mode_enabled {
+            Some("plan".to_string())
+        } else {
+            base_permission.clone()
+        };
+
         backend.call_host(
             "start_session",
             json!({
@@ -175,9 +186,8 @@ impl ClaudeBackend {
                 "cwd": working_directory,
                 "prompt": initial_prompt,
                 "model": claude.and_then(|opts| opts.model.clone()),
-                "permissionMode": claude
-                    .and_then(|opts| opts.permission_mode.clone())
-                    .or_else(|| Some(mode_to_permission_mode(mode).to_string())),
+                "permissionMode": effective_permission,
+                "underlyingPermissionMode": base_permission,
                 "effort": claude.and_then(|opts| opts.effort.clone()),
                 "agent": claude.and_then(|opts| opts.agent.clone()),
                 "claudePath": claude.and_then(|opts| opts.claude_path.clone()),

--- a/apps/desktop/src-tauri/src/agent/codex_backend.rs
+++ b/apps/desktop/src-tauri/src/agent/codex_backend.rs
@@ -42,6 +42,7 @@ impl CodexBackend {
         mode: &AgentMode,
         working_directory: Option<&str>,
         initial_prompt: &str,
+        plan_mode: bool,
         app_handle: AppHandle,
     ) -> Result<Self, String> {
         let cli_path =
@@ -254,15 +255,22 @@ impl CodexBackend {
 
             // Send thread/start request
             let thread_start_id = request_counter.fetch_add(1, Ordering::Relaxed);
+            let mut thread_start_params = serde_json::json!({
+                "approvalPolicy": approval_mode,
+                "cwd": working_directory,
+                "sandboxPermissions": [sandbox_mode],
+            });
+            if plan_mode {
+                thread_start_params.as_object_mut().unwrap().insert(
+                    "config".to_string(),
+                    serde_json::json!({ "plan": true }),
+                );
+            }
             let msg = serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": thread_start_id,
                 "method": "thread/start",
-                "params": {
-                    "approvalPolicy": approval_mode,
-                    "cwd": working_directory,
-                    "sandboxPermissions": [sandbox_mode],
-                }
+                "params": thread_start_params,
             });
             let _ = writer.write_all(msg.to_string().as_bytes());
             let _ = writer.write_all(b"\n");
@@ -599,6 +607,41 @@ fn parse_codex_notification(
                 content_delta: delta,
                 is_error: Some(false),
             }]
+        }
+
+        "plan/delta" | "planDelta" => {
+            let delta = params
+                .get("delta")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let item_id = params
+                .get("itemId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            vec![AgentEvent::PlanDelta {
+                item_id,
+                content_delta: delta,
+            }]
+        }
+
+        "turn/planUpdated" | "turnPlanUpdated" => {
+            let steps = params
+                .get("plan")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|s| {
+                            Some(crate::models::agent::PlanStep {
+                                step: s.get("step")?.as_str()?.to_string(),
+                                status: s.get("status")?.as_str()?.to_string(),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            vec![AgentEvent::PlanUpdated { steps }]
         }
 
         // Approval requests from the server

--- a/apps/desktop/src-tauri/src/agent/manager.rs
+++ b/apps/desktop/src-tauri/src/agent/manager.rs
@@ -25,6 +25,7 @@ struct AgentMeta {
     agent: Option<String>,
     effort: Option<String>,
     claude_path: Option<String>,
+    plan_mode: Option<bool>,
 }
 
 pub struct AgentSessionManager {
@@ -60,6 +61,7 @@ impl AgentSessionManager {
             request.working_directory.as_deref(),
             &request.initial_prompt,
             request.claude.as_ref(),
+            request.plan_mode.or(request.claude.as_ref().and_then(|c| c.plan_mode)),
             app_handle,
         )?;
 
@@ -91,6 +93,7 @@ impl AgentSessionManager {
                 .claude
                 .as_ref()
                 .and_then(|claude| claude.permission_mode.clone()),
+            plan_mode: request.plan_mode.or(request.claude.as_ref().and_then(|c| c.plan_mode)),
             agent: request.claude.as_ref().and_then(|claude| claude.agent.clone()),
             effort: request.claude.as_ref().and_then(|claude| claude.effort.clone()),
             claude_path: request
@@ -125,6 +128,7 @@ impl AgentSessionManager {
                     .claude
                     .as_ref()
                     .and_then(|claude| claude.claude_path.clone()),
+                plan_mode: request.plan_mode.or(request.claude.as_ref().and_then(|c| c.plan_mode)),
             },
         };
 
@@ -212,6 +216,7 @@ impl AgentSessionManager {
                 created_at: entry.info.created_at.clone(),
                 model: entry.info.model.clone(),
                 permission_mode: entry.info.permission_mode.clone(),
+                plan_mode: entry.info.plan_mode,
                 agent: entry.info.agent.clone(),
                 effort: entry.info.effort.clone(),
                 claude_path: entry.info.claude_path.clone(),

--- a/apps/desktop/src-tauri/src/agent/session.rs
+++ b/apps/desktop/src-tauri/src/agent/session.rs
@@ -16,9 +16,11 @@ impl AgentSession {
         working_directory: Option<&str>,
         initial_prompt: &str,
         claude: Option<&ClaudeLaunchOptions>,
+        plan_mode: Option<bool>,
         app_handle: AppHandle,
     ) -> Result<Self, String> {
         let kind = backend_for_cli(cli_name);
+        let resolved_plan_mode = claude.and_then(|c| c.plan_mode).or(plan_mode).unwrap_or(false);
 
         let backend: Box<dyn AgentBackend> = match kind {
             BackendKind::ClaudeStreamJson => Box::new(ClaudeBackend::spawn(
@@ -27,6 +29,7 @@ impl AgentSession {
                 working_directory,
                 initial_prompt,
                 claude,
+                resolved_plan_mode,
                 app_handle,
             )?),
             BackendKind::CodexJson => Box::new(CodexBackend::spawn(
@@ -34,6 +37,7 @@ impl AgentSession {
                 mode,
                 working_directory,
                 initial_prompt,
+                resolved_plan_mode,
                 app_handle,
             )?),
             BackendKind::PtyFallback => {

--- a/apps/desktop/src-tauri/src/models/agent.rs
+++ b/apps/desktop/src-tauri/src/models/agent.rs
@@ -18,6 +18,13 @@ pub struct SlashCommandInfo {
     pub source: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanStep {
+    pub step: String,
+    pub status: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentState {
@@ -38,6 +45,7 @@ pub struct ClaudeLaunchOptions {
     pub effort: Option<String>,
     pub agent: Option<String>,
     pub claude_path: Option<String>,
+    pub plan_mode: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -149,6 +157,15 @@ pub enum AgentEvent {
         total_cost_usd: f64,
         is_error: bool,
     },
+    #[serde(rename_all = "camelCase")]
+    PlanDelta {
+        item_id: String,
+        content_delta: String,
+    },
+    #[serde(rename_all = "camelCase")]
+    PlanUpdated {
+        steps: Vec<PlanStep>,
+    },
     Raw {
         data: serde_json::Value,
     },
@@ -171,6 +188,7 @@ pub struct CreateAgentSessionRequest {
     pub workspace_id: String,
     pub initial_prompt: String,
     pub claude: Option<ClaudeLaunchOptions>,
+    pub plan_mode: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -188,6 +206,7 @@ pub struct AgentSessionInfo {
     pub created_at: String,
     pub model: Option<String>,
     pub permission_mode: Option<String>,
+    pub plan_mode: Option<bool>,
     pub agent: Option<String>,
     pub effort: Option<String>,
     pub claude_path: Option<String>,

--- a/apps/desktop/src/components/agent/AgentStatusBar.tsx
+++ b/apps/desktop/src/components/agent/AgentStatusBar.tsx
@@ -10,6 +10,7 @@ interface AgentStatusBarProps {
   effort?: string | null;
   conversationId?: string | null;
   totalCost: number;
+  planMode?: boolean;
 }
 
 const stateConfig: Record<AgentState, { label: string; icon: typeof Check; spin?: boolean }> = {
@@ -52,10 +53,12 @@ export function AgentStatusBar({
   agent,
   effort,
   totalCost,
+  planMode,
 }: AgentStatusBarProps) {
   const { label, icon: Icon, spin } = stateConfig[state] ?? stateConfig.idle;
 
   const details: string[] = [];
+  if (planMode) details.push("Plan");
   if (model) details.push(formatModel(model));
   if (permissionMode) details.push(PERMISSION_LABELS[permissionMode] ?? permissionMode);
   if (agent) details.push(agent);

--- a/apps/desktop/src/components/agent/ChatView.tsx
+++ b/apps/desktop/src/components/agent/ChatView.tsx
@@ -24,6 +24,7 @@ export function ChatView({ sessionId, variant = "default" }: ChatViewProps) {
   const toggleMessageCollapsed = useAgentStore((s) => s.toggleMessageCollapsed);
   const toggleReasoningCollapsed = useAgentStore((s) => s.toggleReasoningCollapsed);
   const updateTabState = useAgentStore((s) => s.updateTabState);
+  const updateTabMeta = useAgentStore((s) => s.updateTabMeta);
   const updateTabMode = useAgentStore((s) => s.updateTabMode);
   const clearMessages = useAgentStore((s) => s.clearMessages);
   const activeTabId = useAgentStore((s) => s.activeTabId);
@@ -141,6 +142,18 @@ export function ChatView({ sessionId, variant = "default" }: ChatViewProps) {
     [sessionId, updateTabMode],
   );
 
+  const handlePlanModeChange = useCallback(
+    (newPlanMode: boolean) => {
+      updateTabMeta(sessionId, { planMode: newPlanMode });
+      // Send /plan or /default as a message to toggle mid-session
+      const cmd = newPlanMode ? "/plan" : "/default";
+      void agentIpc.sendMessage(sessionId, cmd).catch((err) => {
+        console.error("Failed to toggle plan mode:", err);
+      });
+    },
+    [sessionId, updateTabMeta],
+  );
+
   const handleAbort = useCallback(() => {
     void agentIpc.abort(sessionId).catch((error) => {
       console.error("Failed to abort agent session:", error);
@@ -241,6 +254,7 @@ export function ChatView({ sessionId, variant = "default" }: ChatViewProps) {
         agent={tab.agent}
         effort={tab.effort}
         totalCost={tab.totalCost}
+        planMode={tab?.planMode}
       />
 
       <UnifiedInputCard
@@ -249,6 +263,8 @@ export function ChatView({ sessionId, variant = "default" }: ChatViewProps) {
         agentState={tab.state}
         mode={tab.mode}
         onModeChange={handleModeChange}
+        planMode={tab?.planMode}
+        onPlanModeChange={handlePlanModeChange}
         slashCommands={slashCommands ?? []}
         onFocusChange={(focused) => {
           inputFocusedRef.current = focused;

--- a/apps/desktop/src/components/agent/PreSessionView.tsx
+++ b/apps/desktop/src/components/agent/PreSessionView.tsx
@@ -34,6 +34,7 @@ export function PreSessionView({ tabId, workspaceId }: PreSessionViewProps) {
 
   const [selectedCli, setSelectedCli] = useState<string | null>(null);
   const [mode, setMode] = useState<AgentChatMode>("assisted");
+  const [planMode, setPlanMode] = useState(false);
   const [showFullAccessConfirm, setShowFullAccessConfirm] = useState(false);
   const [creating, setCreating] = useState(false);
   const [model, setModel] = useState("");
@@ -106,12 +107,14 @@ export function PreSessionView({ tabId, workspaceId }: PreSessionViewProps) {
           workingDirectory: effectiveWorkDir,
           workspaceId,
           initialPrompt: text,
+          planMode,
           claude: isClaude
             ? {
                 provider: "claude",
                 model: model.trim() || undefined,
                 permissionMode: mode,
                 effort,
+                planMode,
                 agent: agent.trim() || undefined,
                 claudePath: claudeExecutablePath.trim() || undefined,
               }
@@ -138,6 +141,7 @@ export function PreSessionView({ tabId, workspaceId }: PreSessionViewProps) {
           effort: session.effort ?? (isClaude ? effort : undefined),
           claudePath: session.claudePath ?? (effectiveClaudePath || undefined),
           capabilitiesLoaded: session.capabilitiesLoaded,
+          planMode,
           totalCost: 0,
         });
 
@@ -164,6 +168,7 @@ export function PreSessionView({ tabId, workspaceId }: PreSessionViewProps) {
       isClaude,
       mode,
       model,
+      planMode,
       selectedBranch,
       selectedCli,
       selectedWorktree,
@@ -221,6 +226,8 @@ export function PreSessionView({ tabId, workspaceId }: PreSessionViewProps) {
           disabled={creating}
           mode={mode}
           onModeChange={handleModeChange}
+          planMode={planMode}
+          onPlanModeChange={setPlanMode}
           slashCommands={slashCommands ?? []}
           model={isClaude ? model : undefined}
           onModelChange={isClaude ? setModel : undefined}

--- a/apps/desktop/src/components/agent/SlashCommandMenu.tsx
+++ b/apps/desktop/src/components/agent/SlashCommandMenu.tsx
@@ -12,8 +12,8 @@ import type { SlashCommandInfo } from "@forge/shared";
 export const LOCAL_COMMANDS: SlashCommandInfo[] = [
   { name: "clear", description: "Clear chat history", category: "local" },
   { name: "abort", description: "Stop the running agent", category: "local" },
-  { name: "plan", description: "Switch to Plan mode", category: "local" },
-  { name: "default", description: "Switch to Default mode", category: "local" },
+  { name: "plan", description: "Toggle Plan mode on", category: "local" },
+  { name: "default", description: "Toggle Plan mode off", category: "local" },
   { name: "yolo", description: "Switch to BypassPermissions mode", category: "local" },
   { name: "auto", description: "Switch to Auto mode", category: "local" },
 ];

--- a/apps/desktop/src/components/agent/UnifiedInputCard.tsx
+++ b/apps/desktop/src/components/agent/UnifiedInputCard.tsx
@@ -11,6 +11,7 @@ import {
   Gauge,
   Sparkles,
   Paperclip,
+  ClipboardList,
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -67,6 +68,9 @@ interface UnifiedInputCardProps {
   mode?: AgentChatMode;
   onModeChange?: (mode: AgentChatMode) => void;
 
+  planMode?: boolean;
+  onPlanModeChange?: (planMode: boolean) => void;
+
   slashCommands?: SlashCommandInfo[];
 
   // Model & effort (PreSessionView only)
@@ -96,6 +100,8 @@ export function UnifiedInputCard({
   disabled,
   mode = "assisted",
   onModeChange,
+  planMode,
+  onPlanModeChange,
   slashCommands = [],
   model,
   onModelChange,
@@ -247,6 +253,14 @@ export function UnifiedInputCard({
           case "abort":
             onAbort?.();
             break;
+          case "plan":
+            onPlanModeChange?.(true);
+            showConfirmationMsg("Plan mode enabled");
+            break;
+          case "default":
+            onPlanModeChange?.(false);
+            showConfirmationMsg("Plan mode disabled");
+            break;
           default: {
             const m = MODE_COMMANDS[cmd.name];
             if (m) {
@@ -260,7 +274,7 @@ export function UnifiedInputCard({
       }
       setText("");
     },
-    [onClear, onAbort, onModeChange, onSend, showConfirmationMsg],
+    [onClear, onAbort, onModeChange, onPlanModeChange, onSend, showConfirmationMsg],
   );
 
   const handleSend = useCallback(() => {
@@ -282,6 +296,20 @@ export function UnifiedInputCard({
       return;
     }
 
+    if (lower === "/plan") {
+      onPlanModeChange?.(true);
+      setText("");
+      showConfirmationMsg("Plan mode enabled");
+      return;
+    }
+
+    if (lower === "/default") {
+      onPlanModeChange?.(false);
+      setText("");
+      showConfirmationMsg("Plan mode disabled");
+      return;
+    }
+
     const modeCmd = MODE_COMMANDS[lower.slice(1)];
     if (lower.startsWith("/") && modeCmd) {
       onModeChange?.(modeCmd);
@@ -294,7 +322,7 @@ export function UnifiedInputCard({
     setText("");
     setImages([]);
     setImageError(null);
-  }, [text, images, onSend, onAbort, onModeChange, onClear, showConfirmationMsg]);
+  }, [text, images, onSend, onAbort, onModeChange, onPlanModeChange, onClear, showConfirmationMsg]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -518,6 +546,28 @@ export function UnifiedInputCard({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+
+          {/* Plan mode toggle */}
+          {onPlanModeChange && (
+            <>
+              <Separator />
+              <button
+                type="button"
+                onClick={() => onPlanModeChange(!planMode)}
+                disabled={isDisabled}
+                className={cn(
+                  "flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors disabled:opacity-50",
+                  planMode
+                    ? "text-primary font-semibold bg-primary/10"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+                title={planMode ? "Plan mode ON — agent will propose a plan before executing" : "Plan mode OFF"}
+              >
+                <ClipboardList className="h-3.5 w-3.5" />
+                <span className="font-medium">Plan</span>
+              </button>
+            </>
+          )}
 
           {/* Terminal button (PreSessionView only) */}
           {showTerminalButton && (

--- a/apps/desktop/src/hooks/useAgentSession.ts
+++ b/apps/desktop/src/hooks/useAgentSession.ts
@@ -40,12 +40,24 @@ function handleAgentEvent(payload: AgentEventPayload) {
         ...(event.model ? { model: event.model } : {}),
         ...(event.permissionMode ? { permissionMode: event.permissionMode } : {}),
       });
-      // Sync the UI mode selector when the SDK reports a mode transition
-      // (e.g., plan mode → default after ExitPlanMode approval)
+      // Sync plan mode state from SDK permission mode transitions
       if (event.permissionMode) {
         const tab = store.tabs.find((t) => t.sessionId === sessionId);
-        if (tab && tab.mode !== event.permissionMode) {
-          store.updateTabMode(sessionId, event.permissionMode as AgentChatMode);
+        if (tab) {
+          if (event.permissionMode === "plan") {
+            // SDK entered plan mode
+            store.updateTabMeta(sessionId, { planMode: true });
+          } else if (tab.planMode && event.permissionMode !== "plan") {
+            // SDK exited plan mode (plan approved, now executing)
+            // Keep planMode true in UI, permissionMode reflects execution phase
+          }
+          // Only sync UI mode selector for non-plan permission modes
+          if (event.permissionMode !== "plan" && tab.mode !== event.permissionMode) {
+            const mapped = event.permissionMode as AgentChatMode;
+            if (mapped === "supervised" || mapped === "assisted" || mapped === "fullAccess") {
+              store.updateTabMode(sessionId, mapped);
+            }
+          }
         }
       }
       store.updateTabState(sessionId, "thinking");
@@ -234,6 +246,26 @@ function handleAgentEvent(payload: AgentEventPayload) {
         }
         store.completeReasoning(sessionId);
         store.updateTabState(sessionId, "completed");
+      }
+      break;
+    }
+    case "plan_delta": {
+      // Map plan deltas to assistant message deltas so plan content is visible
+      store.appendAssistantDelta(sessionId, event.itemId, event.contentDelta ?? "");
+      store.updateTabState(sessionId, "thinking");
+      break;
+    }
+    case "plan_updated": {
+      // Format plan steps as an assistant message for display
+      const steps = (event as any).steps as Array<{ step: string; status: string }> | undefined;
+      if (steps?.length) {
+        const formatted = steps
+          .map((s) => {
+            const icon = s.status === "completed" ? "✓" : s.status === "inProgress" ? "→" : "○";
+            return `${icon} ${s.step}`;
+          })
+          .join("\n");
+        store.fillEmptyAssistant(sessionId, formatted);
       }
       break;
     }

--- a/apps/desktop/src/stores/agentStore.ts
+++ b/apps/desktop/src/stores/agentStore.ts
@@ -48,6 +48,7 @@ export interface AgentTab {
   effort?: ClaudeEffort | null;
   claudePath?: string | null;
   capabilitiesLoaded?: boolean;
+  planMode?: boolean;
   slashCommands?: SlashCommandInfo[];
   totalCost: number;
 }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -10,6 +10,7 @@ export interface ClaudeLaunchOptions {
   model?: string;
   permissionMode?: ClaudePermissionMode;
   effort?: ClaudeEffort;
+  planMode?: boolean;
   agent?: string;
   claudePath?: string;
 }
@@ -21,6 +22,7 @@ export interface CreateAgentSessionRequest {
   workspaceId: string;
   initialPrompt: string;
   claude?: ClaudeLaunchOptions;
+  planMode?: boolean;
 }
 
 export interface AgentSessionInfo {
@@ -36,6 +38,7 @@ export interface AgentSessionInfo {
   createdAt: string;
   model?: string;
   permissionMode?: string;
+  planMode?: boolean;
   agent?: string;
   effort?: ClaudeEffort;
   claudePath?: string;
@@ -92,6 +95,8 @@ export type AgentEvent =
       detail: string;
     }
   | { type: "approval_resolved"; approvalId: string; allow: boolean }
+  | { type: "plan_delta"; itemId: string; contentDelta: string }
+  | { type: "plan_updated"; steps: Array<{ step: string; status: "pending" | "inProgress" | "completed" }> }
   | { type: "status"; state: AgentState; tool?: string; toolUseId?: string; messageId?: string; turnId?: string }
   | { type: "result"; resultText: string; durationMs: number; totalCostUsd: number; isError: boolean }
   | { type: "raw"; data: unknown };


### PR DESCRIPTION
## Summary
- Adds end-to-end `plan` mode support across Claude and Codex agent sessions.
- Threads plan state through session creation, persistence, and UI metadata so the desktop app can reflect plan mode consistently.
- Updates agent event handling to surface plan deltas and plan step updates in chat.
- Adds a plan mode toggle in the unified input and pre-session setup, plus `/plan` and `/default` command handling.
- Shows plan mode in the agent status bar and updates slash command labels to match the new behavior.

## Testing
- Not run (not provided in the diff).
- Verified code paths added for session creation, event parsing, and UI toggles by inspection.
- Confirmed new types compile through the shared agent models and frontend props updates by inspection.